### PR TITLE
feat: Initialize database for testing (ref: SPM-37)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ __pycache__/
 .pytest_cache/
 *.pyc
 *.pyo
+.env

--- a/sbrb-backend/README.md
+++ b/sbrb-backend/README.md
@@ -11,17 +11,25 @@ venv\Scripts\activate # make sure you're using cmd
 Step 2: Install dependencies
 
 ```
-pip install requirements.txt
+pip install -r requirements.txt
 ```
 
-Step 3: Run FastAPI Server
+Step 3: Configure environment variables
+
+```
+DB_HOST=<enter your host>
+DB_USERNAME=<enter your username>
+DB_PASSWORD=<enter your password>
+```
+
+Step 4: Run FastAPI Server
 
 ```
 cd app
 python main.py
 ```
 
-Step 4: Visit your endpoint via [localhost:8000](http://localhost:8000/)
+Step 5: Visit your endpoint via [localhost:8000](http://localhost:8000/)
 
 ## Running unit tests
 

--- a/sbrb-backend/app/database.py
+++ b/sbrb-backend/app/database.py
@@ -1,18 +1,37 @@
+import os
+
+from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.engine import URL
 from sqlalchemy.orm import declarative_base, sessionmaker
 
-url = URL.create(
-    database="postgres",
-    drivername="postgresql+psycopg2",
-    host="scrum2023.cplyu5olo9jt.ap-southeast-1.rds.amazonaws.com",
-    username="mickeymouse",
-    password="H124f%4blob",
-    port="5432",
-)
+# Load environment variables from .env file
+load_dotenv()
 
-engine = create_engine(url)
-
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-
+engine = None
+SessionLocal = None
 Base = declarative_base()
+
+
+def init_engine(is_test=False):
+    global engine, SessionLocal
+    database = "test_db" if is_test else "production_db"
+    db_url = URL.create(
+        database=database,
+        drivername="postgresql+psycopg2",
+        host=os.getenv("DB_HOST"),
+        username=os.getenv("DB_USERNAME"),
+        password=os.getenv("DB_PASSWORD"),
+        port="5432",
+    )
+
+    engine = create_engine(db_url, echo=True)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/sbrb-backend/app/models.py
+++ b/sbrb-backend/app/models.py
@@ -1,9 +1,10 @@
 import datetime
 from enum import Enum as PyEnum
 
-from app.database import Base
 from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Text
 from sqlalchemy.orm import relationship
+
+from app.database import Base
 
 
 class Role(Base):

--- a/sbrb-backend/app/models.py
+++ b/sbrb-backend/app/models.py
@@ -1,12 +1,141 @@
-from sqlalchemy import Column, String, Text
+import datetime
+from enum import Enum as PyEnum
 
 from app.database import Base
+from sqlalchemy import Column, DateTime, Enum, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import relationship
 
 
 class Role(Base):
     __tablename__ = "role"
     role_name = Column("rname", String(20), primary_key=True)
     role_desc = Column("description", Text)
+    skills = relationship(
+        "Skill", secondary="role_skill", back_populates="roles", cascade="all, delete"
+    )
+    staff = relationship("Staff", back_populates="role", cascade="all, delete")
+    listing = relationship("Listing", back_populates="role", cascade="all, delete")
 
-    def __repr__(self) -> str:
-        return f"Role(role_name={self.role_name!r}, role_desc={self.role_desc!r})"
+
+class Skill(Base):
+    __tablename__ = "skill"
+    skill_name = Column("sname", String(50), primary_key=True)
+    skill_desc = Column("description", Text)
+    roles = relationship(
+        "Role", secondary="role_skill", back_populates="skills", cascade="all, delete"
+    )
+
+
+class RoleSkill(Base):
+    __tablename__ = "role_skill"
+    role_name = Column(
+        "role_name",
+        String(20),
+        ForeignKey("role.rname", ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    skill_name = Column(
+        "skill_name",
+        String(50),
+        ForeignKey("skill.sname", ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+
+
+class AccessControl(Base):
+    __tablename__ = "access_control"
+    access_id = Column("ac_id", Integer, primary_key=True)
+    access_control_name = Column("ac_name", String(20))
+    staff = relationship("Staff", back_populates="access_control")
+
+
+class Staff(Base):
+    __tablename__ = "staff"
+    staff_id = Column("staff_id", Integer, primary_key=True)
+    staff_fname = Column("staff_fname", String(50), nullable=False)
+    staff_lname = Column("staff_lname", String(50), nullable=False)
+    dept = Column("dept", String(50), nullable=False)
+    country = Column("country", String(50), nullable=False)
+    email = Column("email", String(50), nullable=False)
+
+    role_name = Column("rname", ForeignKey("role.rname"), nullable=False)
+    role = relationship("Role", back_populates="staff")
+
+    access_id = Column(
+        "ac_id", Integer, ForeignKey("access_control.ac_id"), nullable=False
+    )
+    access_control = relationship("AccessControl", back_populates="staff")
+
+    applications = relationship("Application", back_populates="submitted_by")
+
+
+class StaffSkill(Base):
+    __tablename__ = "staff_skill"
+    staff_id = Column(
+        "staff_id",
+        Integer,
+        ForeignKey("staff.staff_id", ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+    skill_name = Column(
+        "skill_name",
+        String(50),
+        ForeignKey("skill.sname", ondelete="CASCADE", onupdate="CASCADE"),
+        primary_key=True,
+    )
+
+
+class Listing(Base):
+    __tablename__ = "listing"
+    listing_id = Column("listing_id", Integer, primary_key=True)
+    role_name = Column("rname", ForeignKey("role.rname"), nullable=False)
+    role = relationship("Role", back_populates="listing")
+
+    listing_title = Column("title", String(50))
+    listing_desc = Column("description", String(50))
+    dept = Column("dept", String(50), nullable=False)
+    country = Column("country", String(50), nullable=False)
+
+    reporting_manager_id = Column(
+        "reporting_manager_id", Integer, ForeignKey("staff.staff_id"), nullable=False
+    )
+    reporting_manager = relationship("Staff", foreign_keys=[reporting_manager_id])
+    created_date = Column("created_date", DateTime, default=datetime.datetime.utcnow)
+    expiry_date = Column("expiry_date", DateTime)
+
+    created_by = Column(
+        "created_by",
+        Integer,
+        ForeignKey("staff.staff_id", ondelete="CASCADE", onupdate="CASCADE"),
+    )
+
+    applications = relationship("Application", back_populates="listing")
+
+
+class ApplicationStatusEnum(PyEnum):
+    PENDING = "Pending"
+    APPROVED = "Approved"
+    REJECTED = "Rejected"
+
+
+class Application(Base):
+    __tablename__ = "application"
+    application_id = Column("application_id", Integer, primary_key=True)
+    submitted_by_id = Column(
+        "submitted_by",
+        Integer,
+        ForeignKey("staff.staff_id", ondelete="CASCADE", onupdate="CASCADE"),
+    )
+    submission_date = Column(
+        "submission_date", DateTime, default=datetime.datetime.utcnow
+    )
+    status = Column(
+        "status", Enum(ApplicationStatusEnum), default=ApplicationStatusEnum.PENDING
+    )
+
+    listing_id = Column(
+        "listing_id", Integer, ForeignKey("listing.listing_id"), nullable=False
+    )
+
+    listing = relationship("Listing", back_populates="applications")
+    submitted_by = relationship("Staff", back_populates="applications")

--- a/sbrb-backend/app/schemas/role_schema.py
+++ b/sbrb-backend/app/schemas/role_schema.py
@@ -1,7 +1,8 @@
 from typing import List
 
-from app.schemas.skill_schema import Skill
 from pydantic import BaseModel
+
+from app.schemas.skill_schema import Skill
 
 
 class Role(BaseModel):

--- a/sbrb-backend/app/schemas/role_schema.py
+++ b/sbrb-backend/app/schemas/role_schema.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from app.schemas.skill_schema import Skill
+from pydantic import BaseModel
+
+
+class Role(BaseModel):
+    role_name: str
+    role_desc: str
+
+
+class RoleWithSkills(Role):
+    skills: List[Skill]

--- a/sbrb-backend/app/schemas/skill_schema.py
+++ b/sbrb-backend/app/schemas/skill_schema.py
@@ -1,0 +1,6 @@
+from pydantic import BaseModel
+
+
+class Skill(BaseModel):
+    skill_name: str
+    skill_desc: str

--- a/sbrb-backend/main.py
+++ b/sbrb-backend/main.py
@@ -1,33 +1,21 @@
 import uvicorn
-from fastapi import Depends, FastAPI
-from sqlalchemy.orm import Session
+from app.database import init_engine
+from fastapi import APIRouter, FastAPI
 
-from app.database import SessionLocal
-from app.models import Role
-
-app = FastAPI()
+api_router = APIRouter()
 
 
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-
-@app.get("/")
-def index():
+@api_router.get("/")
+def get_root():
     return {"message": "Hello World"}
 
 
-@app.get("/roles")
-def get_roles(db: Session = Depends(get_db)):
-    db = SessionLocal()
-    roles = db.query(Role).all()
-    db.close()
-    return roles
+init_engine(is_test=True)
 
+app = FastAPI()
+# Include your API routers
+app.include_router(api_router)
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    app_module = "main:app"
+    uvicorn.run(app_module, host="0.0.0.0", port=8000, reload=True)

--- a/sbrb-backend/main.py
+++ b/sbrb-backend/main.py
@@ -1,6 +1,7 @@
 import uvicorn
-from app.database import init_engine
 from fastapi import APIRouter, FastAPI
+
+from app.database import init_engine
 
 api_router = APIRouter()
 

--- a/sbrb-backend/tests/conftest.py
+++ b/sbrb-backend/tests/conftest.py
@@ -1,11 +1,12 @@
 import os
 
 import pytest
-from app.models import AccessControl, Base, Role, RoleSkill, Skill, Staff, StaffSkill
 from dotenv import load_dotenv
 from sqlalchemy import create_engine
 from sqlalchemy.engine import URL
 from sqlalchemy.orm import sessionmaker
+
+from app.models import AccessControl, Base, Role, RoleSkill, Skill, Staff, StaffSkill
 
 # Load environment variables from .env file
 load_dotenv()

--- a/sbrb-backend/tests/conftest.py
+++ b/sbrb-backend/tests/conftest.py
@@ -1,0 +1,123 @@
+import os
+
+import pytest
+from app.models import AccessControl, Base, Role, RoleSkill, Skill, Staff, StaffSkill
+from dotenv import load_dotenv
+from sqlalchemy import create_engine
+from sqlalchemy.engine import URL
+from sqlalchemy.orm import sessionmaker
+
+# Load environment variables from .env file
+load_dotenv()
+
+
+def populate_test_database(session):
+    # Create sample roles
+    role1 = Role(role_name="Role1", role_desc="Description for Role1")
+    role2 = Role(role_name="Role2", role_desc="Description for Role2")
+
+    # Create sample skills
+    skill1 = Skill(skill_name="Skill1", skill_desc="Description for Skill1")
+    skill2 = Skill(skill_name="Skill2", skill_desc="Description for Skill2")
+    skill3 = Skill(skill_name="Skill3", skill_desc="Description for Skill3")
+    skill4 = Skill(skill_name="Skill4", skill_desc="Description for Skill4")
+    skill5 = Skill(skill_name="Skill5", skill_desc="Description for Skill5")
+
+    # Create sample role-skill relationships
+    role_skill1 = RoleSkill(role_name="Role1", skill_name="Skill1")
+    role_skill2 = RoleSkill(role_name="Role1", skill_name="Skill2")
+    role_skill3 = RoleSkill(role_name="Role2", skill_name="Skill3")
+    role_skill4 = RoleSkill(role_name="Role2", skill_name="Skill4")
+    role_skill5 = RoleSkill(role_name="Role2", skill_name="Skill5")
+
+    # Create sample access controls
+    access_control1 = AccessControl(access_id=1, access_control_name="Access1")
+    access_control2 = AccessControl(access_id=2, access_control_name="Access2")
+
+    # Create sample staff members
+    staff1 = Staff(
+        staff_id=1,
+        staff_fname="John",
+        staff_lname="Doe",
+        dept="HR",
+        country="USA",
+        email="john.doe@example.com",
+        role_name="Role1",
+        access_id=1,
+    )
+    staff2 = Staff(
+        staff_id=2,
+        staff_fname="Jane",
+        staff_lname="Smith",
+        dept="IT",
+        country="Canada",
+        email="jane.smith@example.com",
+        role_name="Role2",
+        access_id=2,
+    )
+
+    # Create sample staff-skill relationships
+    staff_skill1 = StaffSkill(staff_id=1, skill_name="Skill1")
+    staff_skill2 = StaffSkill(staff_id=2, skill_name="Skill2")
+    staff_skill3 = StaffSkill(staff_id=2, skill_name="Skill3")
+    staff_skill4 = StaffSkill(staff_id=2, skill_name="Skill4")
+    staff_skill5 = StaffSkill(staff_id=1, skill_name="Skill5")
+
+    session.add_all(
+        [
+            role1,
+            role2,
+            skill1,
+            skill2,
+            skill3,
+            skill4,
+            skill5,
+            access_control1,
+            access_control2,
+        ]
+    )
+    session.commit()
+
+    session.add_all(
+        [
+            role_skill1,
+            role_skill2,
+            role_skill3,
+            role_skill4,
+            role_skill5,
+            staff1,
+            staff2,
+            staff_skill1,
+            staff_skill2,
+            staff_skill3,
+            staff_skill4,
+            staff_skill5,
+        ]
+    )
+    session.commit()
+
+
+@pytest.fixture(scope="module")
+def db_session():
+    from app.database import SessionLocal, engine
+
+    db_url = URL.create(
+        database="test_db",
+        drivername="postgresql+psycopg2",
+        host=os.getenv("DB_HOST"),
+        username=os.getenv("DB_USERNAME"),
+        password=os.getenv("DB_PASSWORD"),
+        port="5432",
+    )
+    engine = create_engine(db_url, echo=True)
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+    Base.metadata.drop_all(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    session = SessionLocal()
+    try:
+        populate_test_database(session)  # Call the function to add sample data
+        yield session
+    finally:
+        session.close()
+        engine.dispose()

--- a/sbrb-backend/tests/test_main.py
+++ b/sbrb-backend/tests/test_main.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+
 from main import app
 
 client = TestClient(app)

--- a/sbrb-backend/tests/test_main.py
+++ b/sbrb-backend/tests/test_main.py
@@ -1,6 +1,4 @@
 from fastapi.testclient import TestClient
-
-from app.database import Base
 from main import app
 
 client = TestClient(app)


### PR DESCRIPTION
This PR introduces database initialization methods to support testing. The purpose of these scripts is to create a clean database state before running tests, ensuring that tests are executed on a consistent and isolated environment. <!-- ... -->

<!-- Refer to this link to structure your PR title: https://www.conventionalcommits.org/en/v1.0.0/#summary -->
