### PR TITLE
feat: Fetch all open role listing from database (ref: SPM-36)

### DIFF
--- a/.github/workflows/Linting and Testing.yaml
+++ b/.github/workflows/Linting and Testing.yaml
@@ -48,6 +48,7 @@ jobs:
         run: npm run lint
 
   backend-format:
+    needs: [backend-test, frontend-lint]
     runs-on: ubuntu-latest
     permissions: write-all
     continue-on-error: false

--- a/sbrb-backend/app/routes/listing_route.py
+++ b/sbrb-backend/app/routes/listing_route.py
@@ -1,17 +1,29 @@
 from typing import List
 
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
 from app.database import get_db
 from app.schemas.listing_schema import ListingWithSkills
 from app.services.listing_service import ListingService
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
 
 router = APIRouter()
 
 
 @router.get("/listings", status_code=200, response_model=List[ListingWithSkills])
-def get_all_listings(db: Session = Depends(get_db)):
+def get_listings(
+    active: bool = Query(None, description="Filter active listings"),
+    db: Session = Depends(get_db),
+):
     listing_service = ListingService(db)
-    listings = listing_service.get_all_listings_with_skills()
+
+    if active is None:
+        # No 'active' parameter provided, fetch all listings
+        listings = listing_service.get_all_listings_with_skills()
+    else:
+        if active:
+            # 'active=True', fetch active listings
+            listings = listing_service.get_active_listings_with_skills()
+        else:
+            # 'active=False', fetch inactive listings
+            listings = listing_service.get_inactive_listings_with_skills()
     return listings

--- a/sbrb-backend/app/routes/listing_route.py
+++ b/sbrb-backend/app/routes/listing_route.py
@@ -1,10 +1,11 @@
 from typing import List
 
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.orm import Session
+
 from app.database import get_db
 from app.schemas.listing_schema import ListingWithSkills
 from app.services.listing_service import ListingService
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.orm import Session
 
 router = APIRouter()
 

--- a/sbrb-backend/app/services/listing_service.py
+++ b/sbrb-backend/app/services/listing_service.py
@@ -1,7 +1,8 @@
-from sqlalchemy.orm import Session
+from datetime import datetime
 
 from app.models import Listing, Staff
 from app.schemas.listing_schema import ListingWithSkills
+from sqlalchemy.orm import Session
 
 
 class ListingService:
@@ -9,7 +10,27 @@ class ListingService:
         self.db = db
 
     def get_all_listings_with_skills(self):
-        listings = self.db.query(Listing).all()
+        return self.get_listings_with_skills(active=None)
+
+    def get_active_listings_with_skills(self):
+        return self.get_listings_with_skills(active=True)
+
+    def get_inactive_listings_with_skills(self):
+        return self.get_listings_with_skills(active=False)
+
+    def get_listings_with_skills(self, active=None):
+        listings_query = self.db.query(Listing)
+        if active is None:
+            pass
+        elif active:
+            listings_query = listings_query.filter(
+                Listing.expiry_date >= datetime.utcnow()
+            )
+        else:
+            listings_query = listings_query.filter(
+                Listing.expiry_date < datetime.utcnow()
+            )
+        listings = listings_query.all()
         result = []
 
         for listing in listings:

--- a/sbrb-backend/app/services/listing_service.py
+++ b/sbrb-backend/app/services/listing_service.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 
+from sqlalchemy.orm import Session
+
 from app.models import Listing, Staff
 from app.schemas.listing_schema import ListingWithSkills
-from sqlalchemy.orm import Session
 
 
 class ListingService:


### PR DESCRIPTION
This PR adds a new feature to fetch all open role listings from the database (ref: SPM-36).
* `/listings` fetches all role listings
* `/listings?active=true` fetches all open role listings
* `/listings?active=false` fetches all expired role listings

<!-- Refer to this link to structure your PR title: https://www.conventionalcommits.org/en/v1.0.0/#summary -->
